### PR TITLE
Fixed plotting issues in ariaPlot and typos in ariaExtract.

### DIFF
--- a/JupyterDocs/ariaExtract/ariaExtract_tutorial.ipynb
+++ b/JupyterDocs/ariaExtract/ariaExtract_tutorial.ipynb
@@ -30,7 +30,7 @@
     "<div class=\"alert alert-danger\">\n",
     "<b>Potential Errors:</b> \n",
     "    \n",
-    "- If GDAL uses \"HDF5\" driver instead of \"netCDF/Network Common Data Format\" on GUNW products. Verify GDAL version >= 3.\n",
+    "- GDAL uses \"HDF5\" driver instead of \"netCDF/Network Common Data Format\" on GUNW products. Verify GDAL version >= 3.\n",
     "- ARIA-tools needs to be installed to run this notebook\n",
     "</div>\n",
     "\n",
@@ -314,7 +314,7 @@
     "hidden": true
    },
    "source": [
-    "The GUNW product is an InSAR surface displacement product derived from Sentinel-1 SAR data and packaged as netCDF4 files. These products contain both data and meta-data layers such as interferogram amplitude, filtered unwrapped phase, filtered coherence, connected components, perpendicular and parallel baselines, incidence, azimuth and look angles. A detailed overview of the ARIA GUNW product with respect to processing, formatting, sampling, and data layers can be found on the [ARIA website](https://aria.jpl.nasa.gov/node/97)."
+    "The GUNW product is an InSAR surface displacement product derived from Sentinel-1 SAR data and packaged as netCDF4 files. GUNW products contain both data and meta-data layers such as the interferometric amplitude, filtered unwrapped phase, filtered coherence, connected components, perpendicular and parallel baselines, incidence, azimuth and look angles. A detailed overview of the ARIA GUNW product with respect to processing, formatting, sampling, and data layers can be found on the [ARIA website](https://aria.jpl.nasa.gov/node/97)."
    ]
   },
   {
@@ -442,7 +442,7 @@
     "hidden": true
    },
    "source": [
-    "At minimum, users need to specify the GUNW files they want to extract information from. This is controlled using the **`-f`** option. Multiple products can be specified by providing them as a comma separated string (e.g., **`-f`**` 'S1-GUNW-A-R-124-tops-20180502_20180408-043106-21658N_19755N-PP-0dd0-v2_0_1.nc,S1-GUNW-A-R-124-tops-20180502_20180408-043040-20161N_18088N-PP-6704-v2_0_1.nc'`), or using a wildcard (e.g., **`-f`**` 'S1*.nc'`)."
+    "At minimum, users need to specify the GUNW files they want to extract information from. This is controlled using the **`-f`** option. Multiple products can be specified by providing them as a comma separated string (e.g., **`-f`**` 'products/S1-GUNW-A-R-124-tops-20180502_20180408-043106-21658N_19755N-PP-0dd0-v2_0_1.nc,products/S1-GUNW-A-R-124-tops-20180502_20180408-043040-20161N_18088N-PP-6704-v2_0_1.nc'`), or using a wildcard (e.g., **`-f`**` 'products/S1*.nc'`)."
    ]
   },
   {
@@ -537,7 +537,7 @@
     "hidden": true
    },
    "source": [
-    "GUNW products are grouped in clusters that belong to the same interferometric pair. By default, the spatial **intersection** of the interferometic pairs is used to define the region of interest. This can be overwritten to be the union of all interferograms (regardless of alignment) by passing the **`--croptounion`** argument. A schematic example is shown in **Fig 2** for both scenarios.\n",
+    "GUNW products are grouped in clusters that belong to the same interferometric pair. By default, the spatial **intersection** of the interferometic pairs is used to define the region of interest. This can be overriden to be the union of all interferograms (regardless of alignment) by passing the **`--croptounion`** argument. A schematic example is shown in **Fig 2** for both scenarios.\n",
     "\n",
     "<div class=\"alert alert-warning\">\n",
     "<b>Warning:</b> Users in general should avoid mixing products of adjacent satellite tracks (i.e., products made on the same contiguous pass are ok). Note that along the equator, the track number (ascending data on the ascending note) gets incremented while the data itself is still continuous.\n",

--- a/JupyterDocs/ariaPlot/ariaPlot_tutorial.ipynb
+++ b/JupyterDocs/ariaPlot/ariaPlot_tutorial.ipynb
@@ -17,12 +17,12 @@
     "  - Perpendicular baseline versus time plot\n",
     "  - Coherence versus time plot\n",
     "- Spatial coverage plots\n",
-    "  - interferogram latitude extent\n",
+    "  - Interferogram latitude extent\n",
     "    \n",
     "\n",
     "\n",
     "<div class=\"alert alert-warning\">\n",
-    "Both the initial setup (<b>Prep A</b> section) and download of the data (<b>Prep B</b> section) should be run at the start of the notebook. All other sections (Qualitative and Spatial coverage plots) do not need to be run in order\n",
+    "Both the initial setup (<b>Prep A</b> section) and download of the data (<b>Prep B</b> section) should be run at the start of the notebook. All other sections (Qualitative and Spatial coverage plots) do not need to be run in order.\n",
     "</div>\n",
     "\n",
     "<div class=\"alert alert-danger\">\n",
@@ -202,7 +202,9 @@
     "hidden": true
    },
    "source": [
-    "For this tutorial we will use San-Francisco as study area. ARIA provides unwrapped interferograms as GUNW products. We will use a Sentinel-1 interferograms generated on track 42, spanning the start of Sentinel-1 till 20160101. As the spatial extend of a product is roughly the size of a Sentinel-1 SLC frame (250km x 250km), it is likely that an interferogram over your study area is composed of multiple adjacent GUNW frames or products. "
+    "For this tutorial our study area will be San Francisco. ARIA provides unwrapped interferograms as GUNW products. We will use Sentinel-1 interferograms generated on track 42, spanning the start of the Sentinel-1 mission phase in late 2014 up until 20160101. \n",
+    "\n",
+    "ARIA provides unwrapped interferograms as GUNW products. As the spatial extent of a product is roughly the size of a single Sentinel-1 SLC frame (250km x 250km), it is likely that a given interferogram over this study area is composed of multiple adjacent GUNW frames or products. "
    ]
   },
   {
@@ -221,7 +223,7 @@
     "hidden": true
    },
    "source": [
-    "The GUNW product is an InSAR surface displacement products as derived Sentinel-1 and packaged as netCDF4 files. The products contain both data and meta-data layers such as interferogram amplitude, filtered unwrapped phase, filtered coherence, connected components, perpendicular and parallel baselines, incidence, azimuth and look angles. A detailed overview of the ARIA GUNW product with respect to processing, formatting, sampling, and data layers can be found on the [ARIA website](https://aria.jpl.nasa.gov/node/97)."
+    "The GUNW product is an InSAR surface displacement product as derived from Sentinel-1 SAR data and packaged as netCDF4 files. GUNW products contain both data and meta-data layers such as the interferometric amplitude, filtered unwrapped phase, filtered coherence, connected components, perpendicular and parallel baselines, incidence, azimuth and look angles. A detailed overview of the ARIA GUNW product with respect to processing, formatting, sampling, and data layers can be found on the [ARIA website](https://aria.jpl.nasa.gov/node/97)."
    ]
   },
   {
@@ -240,7 +242,7 @@
     "hidden": true
    },
    "source": [
-    "GUNW products are hosted at the ASF DAAC and can be downloaded from the [ARIA-products page](https://aria-products.jpl.nasa.gov) and under beta products from the [ASF DAAC vertex page](https://vertex.daac.asf.alaska.edu). If you know the GUNW filename of the product, you can also build a download link by appending the GUNW filename to **https://<i></i>grfn.asf.alaska.edu<i></i>/door/download/** . \n",
+    "GUNW products are hosted at the ASF DAAC and can be downloaded from the [ARIA-products page](https://aria-products.jpl.nasa.gov) and under beta products from the [ASF DAAC vertex page](https://search.asf.alaska.edu/#/). If you know the GUNW filename of the product, you can also build a download link by appending the GUNW filename to **https://<i></i>grfn.asf.alaska.edu<i></i>/door/download/** . \n",
     "\n",
     "Alternatively, you can use the **`ariaDownload.py`** program provided within the ARIA-tools package to download data using a command-line interface. This program wraps around the ASF DAAC API and allows for search sub setting of GUNW products based on track number, geometry (ascending or descending), as well as, spatial and temporal bounding boxes criteria. For a full description of **`ariaDownload.py`** program, see the [ariaDownload Tutorial](https://github.com/aria-tools/ARIA-tools-docs/blob/master/JupyterDocs/ariaDownload/ariaDownload_tutorial.ipynb).\n",
     "\n",
@@ -256,7 +258,7 @@
     "<b>Download</b>: \n",
     "    \n",
     "- <b>Can take up to 20 min</b>, so this is a good moment to take a cofee-break!\n",
-    "- The ***jupuyter notebook* does not allow for interactive entering of your user-name and password, use the *jupyter terminal* instead** with the same command for interactive use.\n",
+    "- The ***juyter notebook* does not allow for interactive entering of your user-name and password, use the *jupyter terminal* instead** with the same command for interactive use.\n",
     "</div>"
    ]
   },
@@ -269,6 +271,35 @@
    "outputs": [],
    "source": [
     "!ariaDownload.py -t 42 -e 20160101  --bbox \"37.25 38.1 -122.6 -121.75\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "hidden": true
+   },
+   "source": [
+    "We can now have a look at the downloaded products:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hidden": true
+   },
+   "outputs": [],
+   "source": [
+    "!ls products"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "hidden": true
+   },
+   "source": [
+    "The product filename has two fields, **XXYYYN/S-XXYYYN/S**, that are respectively associated with the western edge of south and north most corner of the geocoded interferogram (see [aria-website](https://aria.jpl.nasa.gov/node/97) for a complete overview of the filename convention). The latitude bounds are specified as 5-digit number with 3 significant digits."
    ]
   },
   {
@@ -287,9 +318,9 @@
     "hidden": true
    },
    "source": [
-    "The **`ariaPlot.py`** program allows for easy generation of qualitative and spatio-temporal coverage plots of interferograms over a user-defined area of interest. Running **`ariaPlot.py`** with the **`-h`** option, will show the parameters options. \n",
+    "The **`ariaPlot.py`** program allows for easy generation of qualitative and spatiotemporal coverage plots of products over a user-defined area of interest. Running **`ariaPlot.py`** with the **`-h`** option, will show the parameters options. \n",
     "\n",
-    "Let us explore these options are:"
+    "Let us explore these options:"
    ]
   },
   {
@@ -319,7 +350,7 @@
     "hidden": true
    },
    "source": [
-    "At minimum, users need to specify the GUNW files where they want to extract information from. This is controlled using the **`-f`** option. Multiple products can be specified by providing them as a comma separated string (e.g., **`-f`**` 'S1-GUNW-A-R-124-tops-20180502_20180408-043106-21658N_19755N-PP-0dd0-v2_0_1.nc,S1-GUNW-A-R-124-tops-20180502_20180408-043040-20161N_18088N-PP-6704-v2_0_1.nc'`), or using a wildcard (e.g., **`-f`**` 'S1*.nc'`)."
+    "At minimum, users need to specify the GUNW files they want to extract information from. This is controlled using the **`-f`** option. Multiple products can be specified by providing them as a comma separated string (e.g., **`-f`**` 'products/S1-GUNW-D-R-042-tops-20150605_20150512-140722-39616N_37642N-PP-e396-v2_0_0.nc,products/S1-GUNW-D-R-042-tops-20150629_20150512-140723-39615N_37641N-PP-0e95-v2_0_0.nc'`), or using a wildcard (e.g., **`-f`**` 'products/S1*.nc'`)."
    ]
   },
   {
@@ -329,7 +360,7 @@
     "hidden": true
    },
    "source": [
-    "### 2. Cropping and spatial sub setting (-b and -croptounion options)"
+    "### 2. Cropping and spatial subsetting (-b and -croptounion options)"
    ]
   },
   {
@@ -344,6 +375,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "heading_collapsed": true,
     "hidden": true
    },
    "source": [
@@ -356,7 +388,7 @@
     "hidden": true
    },
    "source": [
-    "GUNW products are grouped in clusters that belong to the same interferometric pair. By default, the spatial **intersection** of the interferometic pairs is used to define the region of interest. This can be overwritten to be the union of all interferograms (regardless of alignment) by passing the **`--croptounion`** argument. A schematic example is shown in **Fig 1** for both scenario's.\n",
+    "GUNW products are grouped in clusters that belong to the same interferometric pair. By default, the spatial **intersection** of the interferometic pairs is used to define the region of interest. This can be overriden to be the union of all interferograms (regardless of alignment) by passing the **`--croptounion`** argument. A schematic example is shown in **Fig 1** for both scenario's.\n",
     "\n",
     "<div class=\"alert alert-warning\">\n",
     "<b>Warning:</b> Users in general should avoid mixing products of adjacent satellite tracks (i.e., products made on the same contiguous pass are ok). Note that along the equator, the track number (ascending data on the ascending note) gets incremented while the data itself is still continuous.\n",
@@ -369,6 +401,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "heading_collapsed": true,
     "hidden": true
    },
    "source": [
@@ -381,10 +414,10 @@
     "hidden": true
    },
    "source": [
-    "The user can specify a rectangular bounding box (South-North-West-East coordinates) as **`-b`**` 'S N W E'` or can provide a more complex area of interest using a shapefile or geoJSON as **`-b`**` path_to_file.shp`. A schematic example is shown in **Fig 2** for both scenario's.\n",
+    "The user can specify a rectangular bounding box (South-North-West-East coordinates) as **`-b`**` 'S N W E'` or can provide a more complex area of interest using a shapefile or geoJSON as **`-b`**` path_to_file.shp`. A schematic example is shown in **Fig 2** for both scenarios.\n",
     "\n",
     "<img src=\"./support_docs/crop.png\" alt=\"cropping\" width=\"700\">\n",
-    "<blockquote><center><b> Fig. 2 </b> Schematic examples of the <b><code>-b</code></b> option available for cropping. The blue dashed line shows the user-specified area of interest. The left panel demonstrates the use when specifying SNWE coordinates, while the right panel shows when specifying a more complex polygon for the area of interest using a shapefile. </center></blockquote>"
+    "<blockquote><center><b> Fig. 2 </b> Schematic examples of the <b><code>-b</code></b> option available for cropping. The blue dashed line shows the user-specified area of interest. The left panel demonstrates the result when specifying SNWE coordinates, while the right panel shows the result when specifying a more complex polygon for the area of interest using a shapefile. </center></blockquote>"
    ]
   },
   {
@@ -403,7 +436,7 @@
     "hidden": true
    },
    "source": [
-    "The output of the **`ariaPlot.py`** program is saved within the working directory (**`-w`**), which by default is the current directory. Within the work directory the outputs of **`ariaPlot.py`** (figures and average coherence raster) are stored within the *figures* directory."
+    "The output of the **`ariaPlot.py`** program is saved within the working directory (**`-w`**), which by default is the current directory. Within the work directory the outputs of **`ariaPlot.py`** (figures and average coherence raster) are stored within the *figures* subdirectory."
    ]
   },
   {
@@ -422,7 +455,7 @@
     "hidden": true
    },
    "source": [
-    "The **`ariaPlot.py`** program leverages GDAL for file reading and writing of outputs. Although most of the outputs are figures, users can specify any GDAL compatible format (e.g., ENVI, ISCE, GTiff; see GDAL for more information on supported format) for saving the output from the **`--makeavgoh`** option."
+    "The **`ariaPlot.py`** program leverages GDAL for file reading and writing of outputs. Although most of the outputs are figures, users can specify any GDAL compatible format (e.g., ENVI, ISCE, GTiff; see GDAL for more information on supported formats) for saving the output from the **`--makeavgoh`** option."
    ]
   },
   {
@@ -441,7 +474,7 @@
     "hidden": true
    },
    "source": [
-    "Users can analyze the interferogram quality over their study area by examining the interferogram baseline and average coherence information. **`ariaPlot.py`** allows user to visualize this information directly from the GUNW products. Three main options are available that can assist users for a qualitative assessment. The **`--plotbperpcoh`** option generates a perpendicular baseline plot over time color-coded with average coherence. An alternative representation is provided by the **`--plotcoh`** option which shows average interferogram coherence over time. Lastly, the **`--makeavgoh`** option can be leveraged for making a 2D product of average coherence in time. \n",
+    "Users can analyze the interferogram quality over their study area using the interferogram baseline and average coherence information. **`ariaPlot.py`** allows users to visualize this information directly from the GUNW products. Three main options are available that can assist users for a qualitative assessment. The **`--plotbperpcoh`** option generates a perpendicular baseline plot over time, color-coded with average coherence. An alternative representation is provided by the **`--plotcoh`** option, which shows just the average interferogram coherence over time. Lastly, the **`--makeavgoh`** option can be leveraged for making a 2D product of average coherence in time. \n",
     "\n",
     "\n",
     "All these can be made at the same time using:"
@@ -484,7 +517,28 @@
     "hidden": true
    },
    "source": [
-    "### 1. Perpendicular baseline with time color-coded with average coherence (--plotbperpcoh)"
+    "Convert EPS format figures to PNG in order to successfully embed figures in the following sections."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hidden": true
+   },
+   "outputs": [],
+   "source": [
+    "!convert figures/bperp_coh_plot.eps figures/bperp_coh_plot.png ; convert figures/avgcoherence_plot.eps figures/avgcoherence_plot.png"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "heading_collapsed": true,
+    "hidden": true
+   },
+   "source": [
+    "### 1. Perpendicular baseline color-coded with average coherence (--plotbperpcoh)"
    ]
   },
   {
@@ -493,11 +547,11 @@
     "hidden": true
    },
    "source": [
-    "Here we visualize the perpendicular baseline figure (*bperp_plot.eps*) generated above. Black markers correspond to individual acquisitions, while interferograms are shown by the lines with the color representing the average coherence. Interferograms with lower average coherence are more decorrelated and prone to unwrapping errors. Generally a seasonal pattern can be observed for the nearest neighbor interferograms.\n",
+    "Here we visualize the perpendicular baseline figure (*bperp_plot.eps*) generated above. Black markers correspond to individual acquisitions, while interferograms are illustrated by the lines and their color representing the average coherence. Interferograms with lower average coherence are more decorrelated and prone to unwrapping errors. Generally a seasonal pattern can be observed for the nearest neighbor interferograms.\n",
     "\n",
-    "<img src=\" figures/bperp_coh_plot.eps\" alt=\"Baseline\" width=\"800\">\n",
+    "<img src=\"figures/bperp_coh_plot.png\" alt=\"bperp_coherence\" width=\"700\">\n",
     "\n",
-    "To generate this figure individually:\n",
+    "To generate this figure alone, run:\n",
     "```\n",
     "!ariaPlot.py -f \"products/*.nc\"  -plotbperpcoh\n",
     "```"
@@ -506,6 +560,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "heading_collapsed": true,
     "hidden": true
    },
    "source": [
@@ -518,11 +573,11 @@
     "hidden": true
    },
    "source": [
-    "Here we visualize the average coherence for each interferogram with time (*avgcoherence_plot.eps*), as calculated above. Black markers correspond to individual acquisitions, while lines correspond to interferograms with the color represented by the average coherence. Interferograms with lower average coherence are more decorrelated and prone to unwrapping errors. Generally a seasonal pattern can be observed for the nearest neighbor interferograms.\n",
+    "Here we visualize the average coherence for each interferogram with time (*avgcoherence_plot.eps*), as also calculated above. Black markers correspond to individual acquisitions, while lines correspond to interferograms with their color representing the average coherence. Interferograms with lower average coherence are more decorrelated and prone to unwrapping errors. Generally a seasonal pattern can be observed for the nearest neighbor interferograms.\n",
     "\n",
-    "<img src=\" figures/avgcoherence_plot.eps\" alt=\"Baseline\" width=\"800\">\n",
+    "<img src=\"figures/avgcoherence_plot.png\" alt=\"average_coherence\" width=\"800\">\n",
     "\n",
-    "To generate this figure individually:\n",
+    "To generate this figure alone, run:\n",
     "```\n",
     "!ariaPlot.py -f \"products/*.nc\"  -plotcoh\n",
     "```"
@@ -531,6 +586,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "heading_collapsed": true,
     "hidden": true
    },
    "source": [
@@ -543,7 +599,12 @@
     "hidden": true
    },
    "source": [
-    "Here we visualize the average coherence raster of all interferograms, as calculated above and stored within the *figures* folder under *avgcoherence*. The raster allows users to get an idea on which regions in their study area have low coherence such as water bodies and vegetated settings. Regions with lower average coherence are more decorrelated and prone to unwrapping errors. Urban regions generally maintain a high coherence overt time.\n"
+    "Here we visualize the average coherence raster of all interferograms, as calculated above and stored within the *figures* folder with the filename *avgcoherence*. This raster allows users to get an idea on which regions in their study area have low coherence (e.g. water bodies and vegetated settings). Regions with lower average coherence are more decorrelated and prone to unwrapping errors. Urban regions generally maintain a high coherence over time.\n",
+    "\n",
+    "To generate this raster alone, run:\n",
+    "```\n",
+    "!ariaPlot.py -f \"products/*.nc\"  -makeavgoh\n",
+    "```"
    ]
   },
   {
@@ -555,18 +616,6 @@
    "outputs": [],
    "source": [
     "plot_layer('figures/avgcoherence.vrt','coherence')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "hidden": true
-   },
-   "source": [
-    "To calculate the average coherence raster individually:\n",
-    "```\n",
-    "!ariaPlot.py -f \"products/*.nc\"  -makeavgoh\n",
-    "```"
    ]
   },
   {
@@ -585,7 +634,7 @@
     "hidden": true
    },
    "source": [
-    "Users can analyze the spatial extend of interferograms over their study area using the **` --plottracks`** option in **`ariaPlot.py`**. The spatial bounding box information is loaded on the fly from GUNW products."
+    "Users can analyze the spatial extent of interferograms over their study area by using the **` --plottracks`** option in **`ariaPlot.py`**. The spatial bounding box information is loaded on the fly from GUNW products."
    ]
   },
   {
@@ -605,6 +654,27 @@
     "hidden": true
    },
    "source": [
+    "Convert EPS format figure to PNG in order to successfully embed figures in the following section."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hidden": true
+   },
+   "outputs": [],
+   "source": [
+    "!convert figures/lat_extents.eps figures/lat_extents.png"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "heading_collapsed": true,
+    "hidden": true
+   },
+   "source": [
     "###  1. Latitude extent of interferograms (--plottracks)"
    ]
   },
@@ -614,9 +684,9 @@
     "hidden": true
    },
    "source": [
-    "Below we visualize the latitude extent as extracted above. Each vertical line shows the latitude extent of an interferogram, while the horizontal lines shows the common intersection area between all interferograms as well as the final bounding box that is used in the processing. By default, the bounding box is set to the common intersection of all interferograms. Users can specify the **`--bbox`** option as well as the **`--croptoptounion`** to change the final bounding box used in the processing.\n",
+    "Below we visualize the latitude extent as extracted above. Each vertical line shows the latitude extent of an interferogram, while the horizontal lines show the common intersection area between all interferograms as well as the final bounding box that is used in the processing. By default, the bounding box is set to the common intersection of all interferograms. Users can modify this default bounding box using the **`--bbox`** option as well as the **`--croptoptounion`**.\n",
     "\n",
-    "<img src=\"figures/lat_extents.eps\" alt=\"Latitude Extents\" width=\"1000\">\n"
+    "<img src=\"figures/lat_extents.png\" alt=\"Latitude_extents\" width=\"1000\">\n"
    ]
   }
  ],
@@ -636,7 +706,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
1. Unable to embed EPS files in notebooks (see https://stackoverflow.com/questions/30991181/ipython-notebook-embed-postscript), easiest solution is to convert figures to PNG first and then embed PNGs. I have implemented this in ariaPlot.
2. Miscellaneous typos in both ariaPlot and ariaExtract