### PR TITLE
Added URL section to ariaDownload

### DIFF
--- a/JupyterDocs/ariaDownload/ariaDownload_tutorial.ipynb
+++ b/JupyterDocs/ariaDownload/ariaDownload_tutorial.ipynb
@@ -115,6 +115,56 @@
     "hidden": true
    },
    "source": [
+    "### Generate list of virtual products from ASF S3 bucket (BETA)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "hidden": true
+   },
+   "source": [
+    "To generate a textfile containing a list of product URLs from the ASF S3 bucket, without downloading data, provide the **`--output`** option with the **`url`** argument. To get information on the exact product filenames also include the verbose option **`-v`**. Extracting layers virtually by leveraging this list of URLs is currently only supported by systems with the following packages: Linux kernel >=4.3 and libnetcdf >=4.5 "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hidden": true
+   },
+   "outputs": [],
+   "source": [
+    "!ariaDownload.py --track 4 --output url"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "hidden": true
+   },
+   "source": [
+    "We can now have a look at the generated textfile, which contains the URLs of all standard products over the specified track:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hidden": true
+   },
+   "outputs": [],
+   "source": [
+    "!more products/download_products_4track_0.txt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "heading_collapsed": true,
+    "hidden": true
+   },
+   "source": [
     "### Generate KMZ of products"
    ]
   },
@@ -443,7 +493,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.6"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,


### PR DESCRIPTION
Added small section on downloading list of URLs from ASF bucket, with the caveat that currently this list cannot be passed directly for extraction without the prerequisite system configs.